### PR TITLE
Using `BOPTestPlant` types

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         version:
           - '1.7'
-          - '1.9'
+          - '1.10'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BOPTestAPI"
 uuid = "4c862b9d-90c3-47b4-a9d1-cc1c4398311d"
 authors = ["Bertrand Kerres"]
-version = "0.1.0-DEV"
+version = "0.1.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/README.md
+++ b/README.md
@@ -4,4 +4,80 @@
 
 Some convenience functions for developing building controllers against the [BOPTEST framework](https://github.com/ibpsa/project1-boptest) in Julia.
 
-**Note**: Development version.
+## Info
+This package can be used to develop building controllers against the BOPTEST REST API.
+
+BOPTEST itself comes in two flavours, the "single-plant" [BOPTEST](https://github.com/ibpsa/project1-boptest) and the larger scale [BOPTEST-Service](https://github.com/NREL/boptest-service), which allows running many plants in parallel.
+
+## Usage
+The general idea is that the BOPTEST services are abstracted away as a `plant`, which only stores metadata about the plant such as the endpoints to use.
+
+For normal BOPTEST (type `BOPTestPlant`), the test case is specified when starting the service, and there is no test ID since only a single plant is running.
+
+For BOPTEST-Service (type `BOPTestServicePlant`), the test case needs to be specified explicitly, and a `testid` UUID is returned by the server that is stored as plant metadata.
+
+### Initialization
+It is recommended to create plants using the initialization functions:
+
+```julia
+# BOPTEST_DEF_URL points to "127.0.0.1:5000", which is the BOPTEST default
+# BOPTEST_SERVICE_DEF_URL points to "http://api.boptest.net", which is where
+# NREL hosts the BOPTEST API
+
+dt = 900.0 # time step in seconds
+local_plant = initboptest!(BOPTEST_DEF_URL, dt)
+
+# and / or
+testcase = "bestest_hydronic"
+remote_plant = initboptestservice!(BOPTEST_SERVICE_DEF_URL, testcase, dt)
+```
+
+### Interaction with the plant
+The package then defines common functions to operate on the plant, namely
+* `inputpoints`, `measurementpoints`, `forecastpoints` to query input, measurement, and forecast signal metadata respectively
+* `getforecast`, `getresults` to get the actual time series data for forecast or past results
+* `advance!`, to step the plant one time step with user-specified control input
+* `stop!`, to stop a test case (BOPTEST-Service only)
+
+#### Querying data
+The signal metadata functions (`inputpoints(plant)`, ...) return a `Vector{Dict}`, while the time series functions return a `Dict{String, Vector}`. However, both can be passed 
+directly to the `DataFrame` constructor without additional arguments. This allows for piping if one wishes.
+
+```julia
+mpts = DataFrame(measurementpoints(plant))
+
+# or by piping
+fcpts = plant |> forecastpoints |> DataFrame
+
+# Query forecast data for 24 hours, with 1/dt sampling frequency
+# The column "Name" contains all available forecast signal names
+fc = getforecast(plant, fcpts.Name, 24*3600, dt) |> DataFrame
+
+# The DataFrames are by default untyped, so for good performance we should convert
+# if possible
+mapcols!(c -> Float64.(c), fc)
+```
+
+#### Advancing
+The `advance!` function requires the control inputs `u` as a `Dict`. Allowed control inputs are test case specific, but can be queried with `inputpoints`.
+
+```julia
+ipts = DataFrame(inputpoints(plant))
+
+# Alternative: Create a simple Dict directly
+# This will by default overwrite all baseline values with the lowest allowed value
+u = controlinputs(plant)
+
+# Simulate 100 steps open-loop
+res_ol = [advance!(plant, u) for _ = 1:100]
+df_ol = DataFrame(res_ol)
+```
+
+#### Stop
+When using BOPTEST-Service, be nice to NREL (or whoever is hosting) and stop a test case when no longer needed:
+
+```julia
+stop!(remote_plant)
+```
+
+This function does nothing when called on a "normal" `BOPTestPlant`

--- a/src/BOPTestAPI.jl
+++ b/src/BOPTestAPI.jl
@@ -87,6 +87,8 @@ Bundle information for transforming data to and from BOPTEST.
 - names : Vector of signal names. **OBS:** Leave out suffixes 
 '_u' and '_activate' for control signals.
 - transform : Function to transform between BOPTEST and controller.
+
+**Note**: Experimental.
 """
 struct SignalTransform
     names::AbstractVector{AbstractString}
@@ -103,6 +105,8 @@ The function calls the transform on `u`, and then creates
 a `Dict` with 2 entries per signal name in `transformer`:
 1. `"<signal_name>_u" => u`
 2. `"<signal_name>_activate" => overwrite`
+
+**Note**: Experimental.
 """
 function controlinputs(
     transformer::SignalTransform,
@@ -428,6 +432,9 @@ function advance!(plant::AbstractBOPTestPlant, u::AbstractDict)
 end
 
 
+# TODO: Check if this function adds any value over just
+# res = [advance!(plant, u) for t=1:N]
+# df = DataFrame(res)
 """
     openloopsim!(
     plant::AbstractBOPTestPlant, N::Int;
@@ -458,6 +465,7 @@ in the dictionary will use the (testcase-specific) default instead.
 The default for `u` is an empty `Dict`, which will use baseline control for
 all signals.
 
+**Note**: Experimental
 """
 function openloopsim!(
     plant::AbstractBOPTestPlant, N::Int;

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,53 @@
 using BOPTestAPI
+using DataFrames
 using Test
 
 @testset "BOPTestAPI.jl" begin
-    # Write your tests here.
+    testcase = "bestest_hydronic"
+    dt = 300.0
+
+    # To use BOPTEST-service
+    plant = initboptestservice!(BOPTEST_SERVICE_DEF_URL, testcase, dt)
+    
+    # To use BOPTEST
+    # plant = initboptest!(BOPTEST_DEF_URL, dt)
+    try
+        @test plant isa BOPTestAPI.AbstractBOPTestPlant
+        
+        fcpts = DataFrame(forecastpoints(plant))
+        @test "Name" in names(fcpts)
+        @test size(fcpts, 1) > 0
+
+        # Piping syntax should also work
+        mpts = plant |> measurementpoints |> DataFrame
+        @test size(mpts, 1) > 0
+
+        res = getresults(plant, mpts.Name, 0.0, 0.0) # Dict
+        @test "time" in keys(res)
+        @test res["reaPPum_y"] isa AbstractVector
+
+        # Get forecast
+        N = 12
+        fc = getforecast(plant, fcpts.Name, N * 3600, 3600) |> DataFrame
+        @test size(fc, 1) == N + 1
+
+        # Control inputs
+        u = controlinputs(plant)
+        @test "ovePum_activate" in keys(u)
+        @test u["ovePum_activate"] == 1
+
+        # Baseline open-loop control
+        df = openloopsim!(plant, N, include_forecast = true)
+        @test df.time[2] - df.time[1] == dt
+        @test size(df, 1) == N + 1
+
+        # KPI
+        kpi = getkpi(plant)
+        @test "ener_tot" in keys(kpi)
+
+    catch e
+        rethrow(e)
+    finally
+        stop!(plant)
+    end
 end


### PR DESCRIPTION
* Abstracted away metadata in a `BOPTestPlant` or `BOPTestServicePlant` respectively.
* Renamed several functions for more consistent naming
* Added docstrings
* Added unit tests
* Usage instructions in README