### PR TITLE
New type system

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BOPTestAPI"
 uuid = "4c862b9d-90c3-47b4-a9d1-cc1c4398311d"
 authors = ["Bertrand Kerres"]
-version = "0.1.1"
+version = "0.2.0-DEV"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -144,12 +144,8 @@ This function does nothing when called on a "normal" `BOPTestPlant`
 BOPTEST_DEF_URL
 BOPTEST_SERVICE_DEF_URL
 BOPTestPlant
-BOPTestServicePlant
 initboptest!
 initboptestservice!
-forecastpoints
-inputpoints
-measurementpoints
 getforecasts
 getmeasurements
 getkpi

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,7 +22,7 @@ testcase = "bestest_hydronic"
 plant = initboptestservice!(BOPTEST_SERVICE_DEF_URL, testcase, dt)
 
 # Get available measurement points
-mpts = plant |> measurementpoints |> DataFrame
+mpts = plant.measurement_points
 mdtable(mpts[1:3, :], latex=false) # hide
 ```
 *(Output truncated)*
@@ -31,8 +31,7 @@ mdtable(mpts[1:3, :], latex=false) # hide
 N = 100
 
 # Get forecast data as well (for plotting later)
-fcpts = plant |> forecastpoints |> DataFrame
-fc = getforecasts(plant, fcpts.Name, N * dt, dt) |> DataFrame
+fc = getforecasts(plant, N * dt, dt)
 
 # Run N time steps of baseline control
 res = []
@@ -51,8 +50,6 @@ mdtable(mapcols(c -> round.(c, digits=2), dfres[1:5, 3:6]), latex=false) # hide
 **And that's it!** You successfully simulated a building HVAC system in the cloud using 
 BOPTEST-Service. The following code will just make some plots of the results.
 ```@example 1
-# typecast forecast to Float64
-mapcols!(c -> Float64.(c), fc)
 # Create single df with all data
 df = leftjoin(dfres, fc, on = :time => :time)
 
@@ -75,15 +72,11 @@ plot(pl1, pl2; layout=(2, 1))
 ## Usage
 (See also the [README on Github](https://github.com/terion-io/BOPTestAPI.jl))
 
-The general idea is that the BOPTEST services are abstracted away as a `plant`, which only stores metadata about the plant such as the endpoints to use.
+The general idea is that the BOPTEST services are abstracted away as a `BOPTestPlant`, which only stores metadata about the plant such as the endpoints to use.
 
 The package then defines common functions to operate on the plant, which are translated to REST API calls and the required data formattings.
 
 ### Initialization
-There are two types of plants, depending on whether they run in BOPTEST or BOPTEST-Service:
-* For normal BOPTEST (type `BOPTestPlant`), the test case is specified when starting the service, and there is no test ID since only a single plant is running.
-* For BOPTEST-Service (type `BOPTestServicePlant`), the test case needs to be specified explicitly, and a `testid` UUID is returned by the server that is stored as plant metadata.
-
 It is recommended to create plants using the initialization functions:
 
 ```julia
@@ -95,38 +88,34 @@ testcase = "bestest_hydronic"
 remote_plant = initboptestservice!(BOPTEST_SERVICE_DEF_URL, testcase, dt)
 ```
 
+The initialization functions also query and store the available signals (as `DataFrame`),
+since they are constant for a testcase. The signals are available as
+* `plant.forecast_points`
+* `plant.input_points`
+* `plant.measurement_points`
+
 ### Interaction with the plant
 The package then defines common functions to operate on the plant, namely
-* `inputpoints`, `measurementpoints`, `forecastpoints` to query input, measurement, and forecast signal metadata respectively
 * `getforecasts`, `getmeasurements` to get the actual time series data for forecast or past measurements
 * `getkpi` to get the KPI for the test case (calculated by BOPTEST)
 * `advance!`, to step the plant one time step with user-specified control input
 * `stop!`, to stop a test case (BOPTEST-Service only)
 
 #### Querying data
-The signal metadata functions (`inputpoints(plant)`, ...) return a `Vector{Dict}`, while the time series functions return a `Dict{String, Vector}`. However, both can be passed 
-directly to the `DataFrame` constructor without additional arguments. This allows for piping if one wishes.
+The time series functions return a `DataFrame` with the time series. By default, a conversion to `Float64` is attempted (else the datatypes would be `Any`). You can use
+the keyword argument `convert_f64=false` to disable conversion.
 
 ```julia
-mpts = DataFrame(measurementpoints(plant))
-
-# or by piping
-fcpts = plant |> forecastpoints |> DataFrame
-
 # Query forecast data for 24 hours, with 1/dt sampling frequency
 # The column "Name" contains all available forecast signal names
-fc = getforecasts(plant, fcpts.Name, 24*3600, dt) |> DataFrame
-
-# The DataFrames are by default untyped, so for good performance we should convert
-# if possible
-mapcols!(c -> Float64.(c), fc)
+fc = getforecasts(plant, 24*3600, dt, plant.forecast_points.Name)
 ```
 
 #### Advancing
-The `advance!` function requires the control inputs `u` as a `Dict`. Allowed control inputs are test case specific, but can be queried with `inputpoints`.
+The `advance!` function requires the control inputs `u` as a `Dict`. Allowed control inputs are test case specific, but can be queried as property `input_points`.
 
 ```julia
-ipts = DataFrame(inputpoints(plant))
+ipts = plant.input_points
 
 # Alternative: Create a simple Dict directly
 # This will by default overwrite all baseline values with the lowest allowed value

--- a/src/BOPTestAPI.jl
+++ b/src/BOPTestAPI.jl
@@ -209,7 +209,7 @@ function initboptest!(
 
         verbose && println("Initialized scenario with ", repr(scenario))
     else
-        res = HTTP.get(plant.api_endpoint("scenario"))
+        res = HTTP.get(api_endpoint("scenario"))
         scenario = JSON.parse(String(res.body))["payload"]
     end
 

--- a/src/BOPTestAPI.jl
+++ b/src/BOPTestAPI.jl
@@ -141,6 +141,7 @@ function initboptestservice!(
     res = HTTP.post(
         "$boptest_url/testcases/$testcase/select",
         ["Content-Type" => "application/json"],
+        JSON.json(Dict()) # This is needed as empty body
     )
     res.status != 200 && error("Could not select BOPTest testcase")
 
@@ -170,7 +171,7 @@ Return a `BOPTestPlant` instance, or throw an `ErrorException` on error.
 
 """
 function initboptest!(
-    api_endpoint::BOPTestEndpoint,
+    api_endpoint::AbstractBOPTestEndpoint,
     dt::Real;
     init_vals = Dict("start_time" => 0, "warmup_period" => 0),
     scenario::Union{Nothing, AbstractDict} = nothing,
@@ -360,7 +361,9 @@ This method does nothing for plants run in normal BOPTEST
 function stop!(plant::BOPTestPlant{BOPTestServiceEndpoint})
     try
         res = HTTP.put(plant.api_endpoint("stop"))
-        res.status == 200 && println("Successfully stopped testid ", plant.testid)
+        res.status == 200 && println(
+            "Successfully stopped testid ", plant.api_endpoint.testid
+        )
     catch e
         if e isa HTTP.Exceptions.StatusError
             payload = JSON.parse(String(e.response.body))

--- a/src/BOPTestAPI.jl
+++ b/src/BOPTestAPI.jl
@@ -205,9 +205,12 @@ function initboptest!(
             ["Content-Type" => "application/json"],
             JSON.json(scenario)
         )
+        res.status != 200 && error("Error setting scenario")
+
         verbose && println("Initialized scenario with ", repr(scenario))
     else
-        scenario = Dict()
+        res = HTTP.get(plant.api_endpoint("scenario"))
+        scenario = JSON.parse(String(res.body))["payload"]
     end
 
     forecast_points = DataFrame(_getpoints(api_endpoint("forecast_points")))

--- a/src/BOPTestAPI.jl
+++ b/src/BOPTestAPI.jl
@@ -1,9 +1,8 @@
 module BOPTestAPI
 
-export BOPTestServicePlant, BOPTestPlant
-export SignalTransform, controlinputs, plantoutputs
-export initboptest!, initboptestservice!, advance!, openloopsim!, stop!
-export forecastpoints, inputpoints, measurementpoints
+export BOPTestPlant
+export controlinputs
+export initboptest!, initboptestservice!, advance!, stop!
 export getforecasts, getmeasurements, getkpi
 export BOPTEST_DEF_URL, BOPTEST_SERVICE_DEF_URL
 
@@ -31,23 +30,23 @@ abstract type AbstractBOPTestEndpoint end
 
 # BOPTEST-Service (https://github.com/NREL/boptest-service)
 # runs several test cases in parallel
-Base.@kwdef struct BOPTestEndpoint <: AbstractBOPTestEndpoint
-    boptest_url::AbstractString
+struct BOPTestEndpoint <: AbstractBOPTestEndpoint
+    base_url::AbstractString
 end
 
-function (plant::BOPTestServiceEndpoint)(service::AbstractString)
-    return "$(plant.boptest_url)/$service/$(plant.testid)"
+function (base::BOPTestEndpoint)(service::AbstractString)
+    return "$(base.base_url)/$service"
 end
 
 # BOPTEST (https://github.com/ibpsa/project1-boptest/) 
 # runs a single test case and thus doesn't have a testid
-Base.@kwdef struct BOPTestServiceEndpoint <: AbstractBOPTestEndpoint
-    boptest_url::AbstractString
+struct BOPTestServiceEndpoint <: AbstractBOPTestEndpoint
+    base_url::AbstractString
     testid::AbstractString
 end
 
-function (plant::BOPTestEndpoint)(service::AbstractString)
-    return "$(plant.boptest_url)/$service"
+function (base::BOPTestServiceEndpoint)(service::AbstractString)
+    return "$(base.base_url)/$service/$(base.testid)"
 end
 
 
@@ -57,16 +56,29 @@ end
 Metadata for a BOPTEST plant.
 
 """
-Base.@kwdef struct BOPTestPlant{EP <: AbstractBOPTestEndpoint} <: AbstractBOPTestPlant
-    endpoint::EP
+struct BOPTestPlant{EP <: AbstractBOPTestEndpoint} <: AbstractBOPTestPlant
+    api_endpoint::EP
     testcase::AbstractString
     scenario::AbstractDict
 
     forecast_points::AbstractDataFrame
-    inputs_points::AbstractDataFrame
+    input_points::AbstractDataFrame
     measurement_points::AbstractDataFrame
 end
 
+function Base.show(io::IO, plant::T) where {T <: AbstractBOPTestPlant}
+    print(io, "$T(", plant.api_endpoint.base_url, ")")
+end
+
+function Base.show(io::IO, ::MIME"text/plain", plant::AbstractBOPTestPlant)
+    show(io, plant)
+    println()
+    if plant.api_endpoint isa BOPTestServiceEndpoint
+        println(io, "Test-ID: ", plant.api_endpoint.testid)
+    end
+    println(io, "Testcase: ", plant.testcase)
+    println(io, "Scenario: ", plant.scenario)
+end
 
 ## Private functions
 
@@ -105,51 +117,6 @@ end
 
 ## Public API
 """
-    SignalTransform(names, transform)
-
-Bundle information for transforming data to and from BOPTEST.
-
-# Arguments
-- names : Vector of signal names. **OBS:** Leave out suffixes 
-'_u' and '_activate' for control signals.
-- transform : Function to transform between BOPTEST and controller.
-
-**Note**: Experimental.
-"""
-struct SignalTransform
-    names::AbstractVector{AbstractString}
-    transform::Function
-end
-
-
-"""
-    controlinputs(transformer::SignalTransform, u, overwrite)
-
-Return `Dict` with control signals for BOPTEST.
-
-The function calls the transform on `u`, and then creates
-a `Dict` with 2 entries per signal name in `transformer`:
-1. `"<signal_name>_u" => u`
-2. `"<signal_name>_activate" => overwrite`
-
-**Note**: Experimental.
-"""
-function controlinputs(
-    transformer::SignalTransform,
-    u::AbstractVector,
-    overwrite::AbstractVector{<:Integer}
-)
-    u = transformer.transform(u)
-    d = Dict{AbstractString, Any}()
-    for (i, s) in enumerate(transformer.names)
-        d[s * "_u"] = u[i]
-        d[s * "_activate"] = Int(overwrite[i])			
-    end
-    return d
-end
-
-
-"""
     controlinputs([f::Function, ]plant::AbstractBOPTestPlant)
 
 Return `Dict` with control signals for BOPTEST.
@@ -168,9 +135,11 @@ input.
 function controlinputs(f::Function, plant::AbstractBOPTestPlant)
     # Default for u: override all controls -> "*_activate" = 1
     # and send u = dfmap(Name)
-    inputs = DataFrame(inputpoints(plant))
-    override_sigs = subset(inputs, :Name => s -> endswith.(s, "_activate"))
-    u_sigs = subset(inputs, :Name => s -> endswith.(s, "_u"))
+    override_sigs = subset(
+        plant.input_points,
+        :Name => s -> endswith.(s, "_activate")
+    )
+    u_sigs = subset(plant.input_points, :Name => s -> endswith.(s, "_u"))
 
     u = Dict(
         Pair.(override_sigs.Name, 1)...,
@@ -180,28 +149,6 @@ function controlinputs(f::Function, plant::AbstractBOPTestPlant)
 end
 
 controlinputs(p::AbstractBOPTestPlant) = controlinputs(df -> df[!, :Minimum], p)
-
-
-"""
-    plantoutput(transformer, d)
-
-Return `Matrix` with scaled outputs from BOPTEST.
-
-The function unpacks `d::Dict` into a matrix where each row
-corresponds to a signal entry that is both in the dict and in
-`transformer.names`, and multiple values (i.e. time) are in the
-column dimension.
-"""
-function plantoutputs(transformer::SignalTransform, d::AbstractDict)
-    m = length(d[transformer.names[1]])
-    x = zeros(length(transformer.names), m)
-    for (i, s) in enumerate(transformer.names)
-        # If scalar value returned (e.g. from /advance), broadcast
-        # since the array is 2D (but with ncols=1)
-        x[i, :] .= d[s]
-    end
-    return transformer.transform(x)
-end
 
 
 """
@@ -224,64 +171,22 @@ function initboptestservice!(
     boptest_url::AbstractString,
     testcase::AbstractString,
     dt::Real;
-    init_vals = Dict("start_time" => 0, "warmup_period" => 0),
-    scenario::Union{Nothing, AbstractDict} = nothing,
-    verbose::Bool = false,
+    kwargs...
 )
     # Select testcase
     res = HTTP.post(
         "$boptest_url/testcases/$testcase/select",
         ["Content-Type" => "application/json"],
-        JSON.json(init_vals)
     )
     res.status != 200 && error("Could not select BOPTest testcase")
 
     payload = JSON.parse(String(res.body))
     testid = payload["testid"]
 
-    # Initialize warmup
-    res = HTTP.put(
-        "$boptest_url/initialize/$testid",
-        ["Content-Type" => "application/json"],
-        JSON.json(init_vals)
-    )
-    res.status != 200 && error("Error initializing testcase")
+    api_endpoint = BOPTestServiceEndpoint(boptest_url, testid)
 
-    # Set simulation step
-    res = HTTP.put(
-        "$boptest_url/step/$testid",
-        ["Content-Type" => "application/json"],
-        JSON.json(Dict("step" => dt))
-    )
-    res.status != 200 && error("Error setting time step")
+    return initboptest!(api_endpoint, dt; kwargs...)
 
-    verbose && println("Initialized testcase=$testcase with step=$(dt)s")
-
-    # Set scenario (electricity prices, ...)
-    if !isnothing(scenario)
-        res = HTTP.put(
-            "$boptest_url/scenario/$testid",
-            ["Content-Type" => "application/json"],
-            JSON.json(scenario)
-        )
-        verbose && println("Initialized scenario with ", repr(scenario))
-    else
-        scenario = Dict()
-    end
-
-    endpoint = BOPTestServiceEndpoint(; boptest_url, testid)
-    forecast_points = DataFrame(_getpoints(endpoint("forecast_points")))
-    input_points = DataFrame(_getpoints(endpoint("inputs")))
-    measurement_points = DataFrame(_getpoints(endpoint("measurements")))
-
-    return BOPTestPlant(;
-        endpoint,
-        testcase,
-        scenario,
-        forecast_points,
-        input_points,
-        measurement_points,
-    )
 end
 
 
@@ -294,7 +199,7 @@ This method does nothing for plants run in normal BOPTEST.
 """
 function stop!(plant::BOPTestPlant{BOPTestServiceEndpoint})
     try
-        res = HTTP.put(plant.endpoint("stop"))
+        res = HTTP.put(plant.api_endpoint("stop"))
         res.status == 200 && println("Successfully stopped testid ", plant.testid)
     catch e
         if e isa HTTP.Exceptions.StatusError
@@ -307,7 +212,9 @@ function stop!(plant::BOPTestPlant{BOPTestServiceEndpoint})
 end
 
 # Hopefully avoids user confusion
-stop!(p::BOPTestPlant{BOPTestEndpoint}) = println("Only plants in BOPTEST-Service can be stopped")
+function stop!(::BOPTestPlant{BOPTestEndpoint})
+    println("Only plants in BOPTEST-Service can be stopped")
+end
 
 
 """
@@ -326,15 +233,16 @@ Return a `BOPTestPlant` instance, or throw an `ErrorException` on error.
 
 """
 function initboptest!(
-    boptest_url::AbstractString,
+    api_endpoint::BOPTestEndpoint,
     dt::Real;
     init_vals = Dict("start_time" => 0, "warmup_period" => 0),
     scenario::Union{Nothing, AbstractDict} = nothing,
     verbose::Bool = false,
 )
+
     # Initialize
     res = HTTP.put(
-        "$boptest_url/initialize",
+        api_endpoint("initialize"),
         ["Content-Type" => "application/json"],
         JSON.json(init_vals)
     )
@@ -342,20 +250,20 @@ function initboptest!(
 
     # Set simulation step
     res = HTTP.put(
-        "$boptest_url/step",
+        api_endpoint("step"),
         ["Content-Type" => "application/json"],
         JSON.json(Dict("step" => dt))
     )
     res.status != 200 && error("Error setting time step")
 
-    res = HTTP.get("$boptest_url/name")
+    res = HTTP.get(api_endpoint("name"))
     testcase = JSON.parse(String(res.body))["payload"]["name"]
     verbose && println("Initialized testcase=$testcase with step=$(dt)s")
     
     # Set scenario (electricity prices, ...)
     if !isnothing(scenario)
         res = HTTP.put(
-            "$boptest_url/scenario",
+            api_endpoint("scenario"),
             ["Content-Type" => "application/json"],
             JSON.json(scenario)
         )
@@ -364,13 +272,12 @@ function initboptest!(
         scenario = Dict()
     end
 
-    endpoint = BOPTestEndpoint(; boptest_url)
-    forecast_points = DataFrame(_getpoints(endpoint("forecast_points")))
-    input_points = DataFrame(_getpoints(endpoint("inputs")))
-    measurement_points = DataFrame(_getpoints(endpoint("measurements")))
+    forecast_points = DataFrame(_getpoints(api_endpoint("forecast_points")))
+    input_points = DataFrame(_getpoints(api_endpoint("inputs")))
+    measurement_points = DataFrame(_getpoints(api_endpoint("measurements")))
 
-    return BOPTestPlant(;
-        endpoint,
+    return BOPTestPlant(
+        api_endpoint,
         testcase,
         scenario,
         forecast_points,
@@ -379,18 +286,9 @@ function initboptest!(
     )
 end
 
-
-function printinfo(plant::AbstractBOPTestPlant, d::AbstractDict)
-    println("TEST CASE INFORMATION ------------- \n")
-    for (k, v) in d
-        res = HTTP.get("$(plant.boptest_url)/$v")
-        payload = JSON.parse(String(res.body))["payload"]
-        if res.status == 200
-            pretty_pl = json(payload, 2)
-            println("$k = ")
-            println(pretty_pl)
-        end
-    end
+function initboptest!(boptest_url::AbstractString, args...; kwargs...)
+    api_endpoint = BOPTestEndpoint(boptest_url)
+    return initboptest!(api_endpoint, args...; kwargs...)
 end
 
 
@@ -400,13 +298,13 @@ end
 Get KPI from BOPTEST server as `Dict`.
 """
 function getkpi(plant::AbstractBOPTestPlant)
-    res = HTTP.get(_endpoint(plant, "kpi"))
+    res = HTTP.get(plant.api_endpoint("kpi"))
     return JSON.parse(String(res.body))["payload"]
 end
 
 
 """
-    getmeasurements(plant::AbstractBOPTestPlant, points, starttime, finaltime)
+    getmeasurements(plant::AbstractBOPTestPlant [, points], starttime, finaltime)
 
 Query measurements from BOPTEST server.
 
@@ -428,17 +326,37 @@ mpts = DataFrame(measurementpoints(plant))
 res = getmeasurements(plant, mpts.Name, 0.0, 12 * 3600.0)
 ```
 """
-function getmeasurements(plant::AbstractBOPTestPlant, points, starttime, finaltime; kwargs...)
+function getmeasurements(
+    plant::AbstractBOPTestPlant,
+    points,
+    starttime::Real,
+    finaltime::Real;
+    coerce_f64::Bool = true,
+    kwargs...
+)
     body = Dict(
         "point_names" => points,
         "start_time" => starttime,
         "final_time" => finaltime,
     )
-    return _getdata(_endpoint(plant, "results"), body; kwargs...)
+    data = _getdata(plant.api_endpoint("results"), body; kwargs...)
+    df = DataFrame(data)
+    if coerce_f64
+        try
+            mapcols!(c -> Float64.(c), df)
+        catch e
+            @warn "Error converting to Float64: $(e)"
+        end
+    end
+    return df
+end
+
+function getmeasurements(p::AbstractBOPTestPlant, s::Real, f::Real; kwargs...)
+    return getmeasurements(p, p.measurement_points.Name, s, f)
 end
 
 """
-    getforecasts(plant::AbstractBOPTestPlant, points, horizon, interval)
+    getforecasts(plant::AbstractBOPTestPlant [, points], horizon, interval)
 
 Query forecast from BOPTEST server.
 
@@ -448,16 +366,35 @@ Query forecast from BOPTEST server.
 - `horizon::Real` : Forecast time horizon from current time step, in seconds.
 - `interval::Real` : Time step size for the forecast data, in seconds.
 
-You can query available forecast points with `forecastpoints(plant)`. 
-See the documentation for `getmeasurements` for more details on extracting available points.
+Available forecast points are stored in `plant.forecast_points`. 
 """
-function getforecasts(plant::AbstractBOPTestPlant, points, horizon, interval; kwargs...)
+function getforecasts(
+    plant::AbstractBOPTestPlant,
+    points,
+    horizon::Real,
+    interval::Real;
+    coerce_f64::Bool = true,
+    kwargs...
+)
     body = Dict(
         "point_names" => points,
         "horizon" => horizon,
         "interval" => interval
     )
-    return _getdata(_endpoint(plant, "forecast"), body; kwargs...)
+    data = _getdata(plant.api_endpoint("forecast"), body; kwargs...)
+    df = DataFrame(data)
+    if coerce_f64
+        try
+            mapcols!(c -> Float64.(c), df)
+        catch e
+            @warn "Error converting to Float64: $(e)"
+        end
+    end
+    return df
+end
+
+function getforecasts(p::AbstractBOPTestPlant, h::Real, i::Real; kwargs...)
+    return getforecasts(p, p.forecast_points.Name, h, i; kwargs...)
 end
 
 """
@@ -473,7 +410,7 @@ Returns the payload as `Dict{String, Vector}`.
 """
 function advance!(plant::AbstractBOPTestPlant, u::AbstractDict)
 	res = HTTP.post(
-		_endpoint(plant, "advance"),
+		plant.api_endpoint("advance"),
 		["Content-Type" => "application/json"],
 		JSON.json(u);
 		retry_non_idempotent=true
@@ -481,92 +418,6 @@ function advance!(plant::AbstractBOPTestPlant, u::AbstractDict)
 	
 	payload_dict = JSON.parse(String(res.body))["payload"]
     return payload_dict
-end
-
-
-# TODO: Check if this function adds any value over just
-# res = [advance!(plant, u) for t=1:N]
-# df = DataFrame(res)
-"""
-    openloopsim!(
-    plant::AbstractBOPTestPlant, N::Int;
-    u = Dict(),
-    include_forecast::Bool = false,
-    print_every::Int = 0,
-)
-
-Run the plant in open loop simulation for N steps of time dt.
-
-# Arguments
-- `plant::AbstractBOPTestPlant` : Plant to simulate.
-- `N::Int` : Number of time steps.
-- `u`::AbstractDict : Control inputs for the active test case. See below for options.
-- `include_forecast::Bool` : Include forecasts in the returned `DataFrame`.
-- `print_every::Int` : How often to print the current time step, or 0 to disable
-
-# Control inputs
-Control inputs are passed through parameter `u`. The options are:
-- `AbstractVector{Dict}`, where item `i` is control input at time step `i`.
-- A scalar `Dict`, which means a constant control input at all time steps.
-
-The dictionaries should contain mappings `"<signal_name>" => <value>`.
-Use `inputpoints(plant)` to query available inputs. Input signals not found
-in the dictionary will use the (testcase-specific) default instead.
-
-The default for `u` is an empty `Dict`, which will use baseline control for
-all signals.
-
-**Note**: Experimental
-"""
-function openloopsim!(
-    plant::AbstractBOPTestPlant, N::Int;
-    u = Dict(),
-    include_forecast::Bool = false,
-    print_every::Int = 0,
-)
-    res = HTTP.get(_endpoint(plant, "step"))
-    dt = JSON.parse(String(res.body))["payload"]
-    
-    if include_forecast
-        fcpts = DataFrame(forecastpoints(plant))
-        forecast = getforecasts(plant, fcpts.Name, N*dt, dt)
-    else
-        forecast = Dict()
-    end
-
-    if !(u isa AbstractVector)
-        # Constant control inputs
-        u = fill(u, N)
-    end
-
-
-    length(u) >= N || throw(DimensionMismatch("Need at least $N control input entries."))
-
-	measurements = DataFrame(measurementpoints(plant))
-    y_transform = SignalTransform(measurements.Name, y -> y)
-
-    print_every > 0 && println("Starting open-loop simulation")
-
-    Y = zeros(size(measurements, 1), N+1)
-    y0d = getmeasurements(plant, measurements.Name, 0.0, 0.0)
-    Y[:, 1] = plantoutputs(y_transform, y0d)
-
-    for j = 2:N+1
-        (print_every > 0) && (j % print_every == 0) && println("Current time step = ",  j)
-        _d = advance!(plant, u[j-1])
-		Y[:, j] = plantoutputs(y_transform, _d)
-	end
-
-	# This solution would always return 30-sec interval data:
-    # res = BOPTestAPI.getresults(endpoint, measurements.Name, 0, N*dt)
-	df = DataFrame(Y', measurements.Name)
-
-    # Add forecast variables (no cols if not queried)
-    for (k, v) in forecast
-        insertcols!(df, k => v)
-    end
-
-    return df
 end
 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,11 +7,16 @@ using Test
 @testset "BOPTestAPI.jl" begin
     testcase = "bestest_hydronic"
     dt = 300.0
+    scenario = Dict(
+        "electricity_price" => "highly_dynamic",
+    # Note: This seems to not work on the server side
+    #    "time_period" => "typical_heat_day" 
+    )
 
     # To use BOPTEST-service
     plant = initboptestservice!(
         BOPTEST_SERVICE_DEF_URL, testcase, dt;
-        verbose = true
+        scenario, verbose = true
     )
     
     # To use BOPTEST

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,5 @@
+import BOPTestAPI: AbstractBOPTestPlant
+
 using BOPTestAPI
 using DataFrames
 using Test
@@ -7,32 +9,31 @@ using Test
     dt = 300.0
 
     # To use BOPTEST-service
-    plant = initboptestservice!(
-        BOPTEST_SERVICE_DEF_URL, testcase, dt;
-        verbose = true
-    )
+    # plant = initboptestservice!(
+    #     BOPTEST_SERVICE_DEF_URL, testcase, dt;
+    #     verbose = true
+    # )
     
     # To use BOPTEST
-    # plant = initboptest!(BOPTEST_DEF_URL, dt)
+    plant = initboptest!(BOPTEST_DEF_URL, dt)
     try
-        @test plant isa BOPTestAPI.AbstractBOPTestPlant
+        @test plant isa AbstractBOPTestPlant
         
-        fcpts = DataFrame(forecastpoints(plant))
+        fcpts = plant.forecast_points
         @test "Name" in names(fcpts)
         @test size(fcpts, 1) > 0
 
-        # Piping syntax should also work
-        mpts = plant |> measurementpoints |> DataFrame
-        @test size(mpts, 1) > 0
+        @test size(plant.measurement_points, 1) > 0
 
-        res = getmeasurements(plant, mpts.Name, 0.0, 0.0) # Dict
-        @test "time" in keys(res)
-        @test res["reaPPum_y"] isa AbstractVector
+        dfres = getmeasurements(plant, 0.0, 0.0) # DataFrame
+        @test "time" in names(dfres)
+        @test dfres[!, "reaPPum_y"] isa AbstractVector{Float64}
 
         # Get forecast
         N = 12
-        fc = getforecasts(plant, fcpts.Name, N * 3600, 3600) |> DataFrame
+        fc = getforecasts(plant, N * 3600, 3600, ["lat", "lon"])
         @test size(fc, 1) == N + 1
+        @test size(fc, 2) == 3
 
         # Control inputs
         u = controlinputs(plant)
@@ -40,9 +41,16 @@ using Test
         @test u["ovePum_activate"] == 1
 
         # Baseline open-loop control
-        df = openloopsim!(plant, N, include_forecast = true)
+        res = []
+        u = Dict()
+        for t = 1:N
+            y = advance!(plant, u)
+            push!(res, y)
+        end
+
+        df = DataFrame(res)
         @test df.time[2] - df.time[1] == dt
-        @test size(df, 1) == N + 1
+        @test size(df, 1) == N
 
         # KPI
         kpi = getkpi(plant)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,13 +9,13 @@ using Test
     dt = 300.0
 
     # To use BOPTEST-service
-    # plant = initboptestservice!(
-    #     BOPTEST_SERVICE_DEF_URL, testcase, dt;
-    #     verbose = true
-    # )
+    plant = initboptestservice!(
+        BOPTEST_SERVICE_DEF_URL, testcase, dt;
+        verbose = true
+    )
     
     # To use BOPTEST
-    plant = initboptest!(BOPTEST_DEF_URL, dt)
+    # plant = initboptest!(BOPTEST_DEF_URL, dt)
     try
         @test plant isa AbstractBOPTestPlant
         


### PR DESCRIPTION
## Changelog
### Changed
* Endpoints encapsulated in own types `<: AbstractBOPTestEndpoint`
* Only one plant type `BOPTestPlant{T}`, where `T` denotes the endpoint type
* Store `input_points`, `measurement_points`, `forecast_points` on construction as `DataFrame`, 

### Removed
* Removed the query methods `inputpoints`, `measurementpoints`, `forecastpoints`
* Removed `openloopsim!` (not enough value add over a simple loop)
* Removed experimental `SignalTransform`, `plantoutputs` (to be replaced by environment wrappers)