### PR TITLE
Changes for BOPTEST v0.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BOPTestAPI"
 uuid = "4c862b9d-90c3-47b4-a9d1-cc1c4398311d"
 authors = ["Bertrand Kerres"]
-version = "0.3.0-DEV"
+version = "0.3.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BOPTestAPI"
 uuid = "4c862b9d-90c3-47b4-a9d1-cc1c4398311d"
 authors = ["Bertrand Kerres"]
-version = "0.2.0"
+version = "0.3.0-DEV"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/README.md
+++ b/README.md
@@ -19,25 +19,26 @@ The package then defines common functions to operate on the plant, which are tra
 
 ### Initialization
 There are two subtypes of plants, depending on whether they run in BOPTEST or BOPTEST-Service:
-* For normal BOPTEST (type `BOPTestPlant{BOPTestEndpoint}`), the test case is specified when starting the service, and there is no test ID since only a single plant is running.
-* For BOPTEST-Service (type `BOPTestPlant{BOPTesServicetEndpoint}`), the test case needs to be specified explicitly, and a `testid` UUID is returned by the server that is stored as endpoint metadata.
+* Type `BOPTestPlant{BOPTestEndpoint}`, for local BOPTEST `< v0.7`. The test case is specified when starting the service, and there is no test ID since only a single plant is running. Use `initboptest!(url)` for creating a plant.
+* Type `BOPTestPlant{BOPTesServiceEndpoint}`, for BOPTEST `>= v0.7` or remote plants. The test case needs to be specified explicitly, and a `testid` UUID is returned by the server that is stored as endpoint metadata. Use `BOPTestPlant(url, testcase)` for creating a plant.
+
+> [!IMPORTANT]
+> BOPTEST from version `v0.7.0` uses the BOPTEST-service API even on local deployment. Thus, since BOPTestAPI v0.3, the `BOPTestPlant` constructor is overloaded and can be used directly.
 
 > [!TIP]
 > For a plant instance, `plant.api_endpoint(service)` is callable and returns the endpoint of a specific service as `String`, this can be useful for defining additional functions.
 
-It is recommended to create plants using the initialization functions:
-
 ```julia
-# BOPTEST_DEF_URL points to "127.0.0.1:5000", which is the BOPTEST default
-# BOPTEST_SERVICE_DEF_URL points to "http://api.boptest.net", which is where
-# NREL hosts the BOPTEST API
-
-dt = 900.0 # time step in seconds
-local_plant = initboptest!(BOPTEST_DEF_URL, dt)
-
-# and / or
 testcase = "bestest_hydronic"
-remote_plant = initboptestservice!(BOPTEST_SERVICE_DEF_URL, testcase, dt)
+# NREL hosts the BOPTEST API "http://api.boptest.net"
+remote_plant = BOPTestPlant("http://api.boptest.net", testcase)
+
+local_plant = BOPTestPlant("http://localhost", testcase)
+
+# !! Note: For BOPTEST < v0.7 use this for local deployed test cases
+# The test case is thenset when starting up BOPTEST
+local_plant = initboptest!("http://localhost")
+
 ```
 
 The initialization functions also query and store the available signals (as `DataFrame`),
@@ -51,7 +52,7 @@ The package then defines common functions to operate on the plant, namely
 * `getforecasts`, `getmeasurements` to get the actual time series data for forecast or past measurements
 * `getkpi` to get the KPI for the test case (calculated by BOPTEST)
 * `advance!`, to step the plant one time step with user-specified control input
-* `stop!`, to stop a test case (BOPTEST-Service only)
+* `stop!`, to stop a test case
 
 #### Querying data
 The time series functions return a `DataFrame` with the time series. By default, a conversion to `Float64` is attempted (else the datatypes would be `Any`). You can use
@@ -78,10 +79,8 @@ kpi = getkpi(plant)
 ```
 
 #### Stop
-When using BOPTEST-Service, be nice to NREL (or whoever is hosting) and stop a test case when no longer needed:
+Stop a test case when no longer needed:
 
 ```julia
-stop!(remote_plant)
+stop!(plant)
 ```
-
-This function does nothing when called on a "normal" `BOPTestPlant`.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ remote_plant = BOPTestPlant("http://api.boptest.net", testcase)
 local_plant = BOPTestPlant("http://localhost", testcase)
 
 # !! Note: For BOPTEST < v0.7 use this for local deployed test cases
-# The test case is thenset when starting up BOPTEST
+# The test case is then set when starting up BOPTEST
 local_plant = initboptest!("http://localhost")
 
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -19,7 +19,7 @@ using Latexify # hide
 dt = 900.0 # time step in seconds
 testcase = "bestest_hydronic"
 
-plant = initboptestservice!(BOPTEST_SERVICE_DEF_URL, testcase, dt)
+plant = BOPTestPlant("http://api.boptest.net", testcase, dt=dt)
 
 # Get available measurement points
 mpts = plant.measurement_points
@@ -77,15 +77,16 @@ The general idea is that the BOPTEST services are abstracted away as a `BOPTestP
 The package then defines common functions to operate on the plant, which are translated to REST API calls and the required data formattings.
 
 ### Initialization
-It is recommended to create plants using the initialization functions:
+Use the `BOPTestPlant` constructor:
 
 ```julia
 dt = 900.0 # time step in seconds
-local_plant = initboptest!(BOPTEST_DEF_URL, dt)
 
-# and / or
 testcase = "bestest_hydronic"
-remote_plant = initboptestservice!(BOPTEST_SERVICE_DEF_URL, testcase, dt)
+plant = BOPTestPlant("http://localhost", testcase, dt = dt)
+
+# For old BOPTEST < v0.7, use the deprecated initboptest! function
+old_plant = initboptest!("http://127.0.0.1:5000", dt = dt)
 ```
 
 The initialization functions also query and store the available signals (as `DataFrame`),
@@ -130,22 +131,15 @@ kpi = getkpi(plant)
 ```
 
 #### Stop
-When using BOPTEST-Service, be nice to NREL (or whoever is hosting) and stop a test case when no longer needed:
+Stop a test case when no longer needed:
 
 ```julia
-stop!(remote_plant)
+stop!(plant)
 ```
-
-This function does nothing when called on a "normal" `BOPTestPlant`
-
 
 ## API
 ```@docs
-BOPTEST_DEF_URL
-BOPTEST_SERVICE_DEF_URL
 BOPTestPlant
-initboptest!
-initboptestservice!
 getforecasts
 getmeasurements
 getkpi

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -140,6 +140,7 @@ stop!(plant)
 ## API
 ```@docs
 BOPTestPlant
+initboptest!
 getforecasts
 getmeasurements
 getkpi

--- a/src/BOPTestAPI.jl
+++ b/src/BOPTestAPI.jl
@@ -140,7 +140,7 @@ function _initboptestservice!(
 
     api_endpoint = BOPTestServiceEndpoint(boptest_url, testid)
 
-    return initboptest!(api_endpoint; kwargs...)
+    return _initboptest!(api_endpoint; kwargs...)
 
 end
 

--- a/src/BOPTestAPI.jl
+++ b/src/BOPTestAPI.jl
@@ -41,9 +41,18 @@ end
 abstract type AbstractBOPTestPlant end
 
 """
-    struct BOPTestPlant <: AbstractBOPTestPlant
+    BOPTestPlant(boptest_url, testcase[; dt, init_vals, scenario, verbose])
 
-Metadata for a BOPTEST plant.
+Initialize a testcase in BOPTEST service with step size dt.
+
+# Arguments
+- `boptest_url`: URL of the BOPTEST-Service API to initialize.
+- `testcase` : Name of the test case, [list here](https://ibpsa.github.io/project1-boptest/testcases/index.html).
+## Keyword arguments
+- `dt::Real`: Time step in seconds.
+- `init_vals::AbstractDict`: Parameters for the initialization.
+- `scenario::AbstractDict` : Parameters for scenario selection.
+- `verbose::Bool`: Print something to stdout.
 
 """
 Base.@kwdef struct BOPTestPlant{EP <: AbstractBOPTestEndpoint} <: AbstractBOPTestPlant
@@ -56,22 +65,6 @@ Base.@kwdef struct BOPTestPlant{EP <: AbstractBOPTestEndpoint} <: AbstractBOPTes
     measurement_points::AbstractDataFrame
 end
 
-"""
-    BOPTestPlant(boptest_url, testcase, dt[; init_vals, scenario, verbose])
-
-Initialize a testcase in BOPTEST service with step size dt.
-
-# Arguments
-## Required arguments
-- `boptest_url`: URL of the BOPTEST-Service API to initialize.
-- `testcase` : Name of the test case, [list here](https://ibpsa.github.io/project1-boptest/testcases/index.html).
-## Keyword arguments
-- `dt::Real`: Time step in seconds.
-- `init_vals::AbstractDict`: Parameters for the initialization.
-- `scenario::AbstractDict` : Parameters for scenario selection.
-- `verbose::Bool`: Print something to stdout.
-
-"""
 function BOPTestPlant(
     boptest_url::AbstractString,
     testcase::AbstractString;
@@ -210,17 +203,15 @@ function _initboptest!(
 end
 
 ## Public API
-
 @deprecate initboptestservice!(boptest_url, testcase, dt; kwargs...) BOPTestPlant(boptest_url, testcase; dt, kwargs...)
 
 
 """
-    initboptest!(boptest_url, dt[; init_vals, scenario, verbose])
+    initboptest!(boptest_url[; dt, init_vals, scenario, verbose])
 
-Initialize the BOPTEST server with step size dt.
+[**Warning:** Deprecated.] Initialize the local BOPTEST server.
 
 # Arguments
-## Required
 - `boptest_url`: URL of the BOPTEST server to initialize.
 ## Keyword arguments
 - `dt::Real`: Time step in seconds.
@@ -229,6 +220,9 @@ Initialize the BOPTEST server with step size dt.
 - `verbose::Bool`: Print something to stdout.
 
 Return a `BOPTestPlant` instance, or throw an `ErrorException` on error.
+
+**Warning:** This function is deprecated, since BOPTEST v0.7 switched to the
+BOPTEST-Service API. Use it for a locally deployed `BOPTEST < v0.7`.
 
 """
 function initboptest!(

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,13 +14,13 @@ using Test
     )
 
     # To use BOPTEST-service
-    plant = initboptestservice!(
-        BOPTEST_SERVICE_DEF_URL, testcase, dt;
-        scenario, verbose = true
+    # base_url = "http://localhost"
+    base_url = "http://api.boptest.net"
+    plant = BOPTestPlant(
+        base_url, testcase;
+        dt, scenario, verbose = true
     )
     
-    # To use BOPTEST
-    # plant = initboptest!(BOPTEST_DEF_URL, dt)
     try
         @test plant isa AbstractBOPTestPlant
         


### PR DESCRIPTION
## Deprecated
* Initializations `initboptest!`, `initboptestservice!`
* Exported constants `BOPTEST_DEF_URL`, `BOPTEST_SERVICE_DEF_URL`

## Added
* Constructor `BOPTestPlant(url, testcase, kwargs...)` to initialize new test cases