### PR TITLE
21 use logging instead of println for all output

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BOPTestAPI"
 uuid = "4c862b9d-90c3-47b4-a9d1-cc1c4398311d"
 authors = ["Bertrand Kerres"]
-version = "0.4.1"
+version = "0.5.0-DEV"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ using Test
     base_url = "http://api.boptest.net"
     plant = BOPTestPlant(
         base_url, testcase;
-        dt, scenario, verbose = true
+        dt, scenario
     )
     
     try


### PR DESCRIPTION
* Using `Logging` module throughout
* Added convenience method `stop!(base_url, testid)`