### PR TITLE
27 use methods instead of field name access in public api

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ local_plant = initboptest!("http://127.0.0.1:5000")
 
 The initialization functions also query and store the available signals (as `DataFrame`),
 since they are constant for a testcase. The signals are available as
-* `plant.forecast_points`
-* `plant.input_points`
-* `plant.measurement_points`
+* `forecast_points(plant)`
+* `input_points(plant)`
+* `measurement_points(plant)`
 
 ### Interaction with the plant
 The package then defines common functions to operate on the plant, namely

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,6 @@
 using Documenter, BOPTestAPI
 
-makedocs(sitename="BOPTestAPI.jl")
+makedocs(sitename="BOPTestAPI.jl", modules = [BOPTestAPI])
 
 deploydocs(
     repo = "github.com/terion-io/BOPTestAPI.jl.git",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -138,16 +138,33 @@ stop!(plant)
 ```
 
 ## API
+### Types
 ```@docs
 BOPTestPlant
 CachedBOPTestPlant
+```
+### Accessors
+```@docs
+forecast_points
+input_points
+measurement_points
+forecasts
+past_inputs
+measurements
+```
+### Interaction
+```@docs
 initialize!
 initboptest!
 setscenario!
 getforecasts
 getmeasurements
 getkpi
+getstep
 advance!
 stop!
+```
+### Utils
+```@docs
 controlinputs
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -22,7 +22,7 @@ testcase = "bestest_hydronic"
 plant = BOPTestPlant("http://api.boptest.net", testcase, dt=dt)
 
 # Get available measurement points
-mpts = plant.measurement_points
+mpts = measurement_points(plant)
 mdtable(mpts[1:3, :], latex=false) # hide
 ```
 *(Output truncated)*
@@ -91,9 +91,9 @@ old_plant = initboptest!("http://127.0.0.1:5000", dt = dt)
 
 The initialization functions also query and store the available signals (as `DataFrame`),
 since they are constant for a testcase. The signals are available as
-* `plant.forecast_points`
-* `plant.input_points`
-* `plant.measurement_points`
+* `forecast_points(plant)`
+* `input_points(plant)`
+* `measurement_points(plant)`
 
 ### Interaction with the plant
 The package then defines common functions to operate on the plant, namely
@@ -116,7 +116,7 @@ fc = getforecasts(plant, 24*3600, dt, plant.forecast_points.Name)
 The `advance!` function requires the control inputs `u` as a `Dict`. Allowed control inputs are test case specific, but can be queried as property `input_points`.
 
 ```julia
-ipts = plant.input_points
+ipts = input_points(plant)
 
 # Alternative: Create a simple Dict directly
 # This will by default overwrite all baseline values with the lowest allowed value
@@ -149,7 +149,7 @@ forecast_points
 input_points
 measurement_points
 forecasts
-past_inputs
+inputs_sent
 measurements
 ```
 ### Interaction

--- a/src/BOPTestAPI.jl
+++ b/src/BOPTestAPI.jl
@@ -1,9 +1,11 @@
 module BOPTestAPI
 
 export BOPTestPlant, CachedBOPTestPlant
+export forecast_points, input_points, measurement_points
+export forecasts, past_inputs, measurements
 export controlinputs
 export initboptest!, initialize!, advance!, setscenario!, stop!
-export getforecasts, getmeasurements, getkpi
+export getforecasts, getmeasurements, getkpi, getstep
 
 using HTTP
 using JSON
@@ -93,14 +95,6 @@ are updated when calling `advance!`.
 - `N::Int`: Forecast cache size
 ## Keyword arguments
 See the documentation for `BOPTestPlant`.
-
-# Additional Fields
-- `dt::Float64`: Step size
-- `forecasts::DataFrame`: Forecast from current timestep
-- `inputs::DataFrame`: Inputs as submitted. Uses `missing` if no value was given for an \
-input.
-- `measurements::DataFrame`: Measurements as returned from `advance!`. Also contains the \
-actual actuator inputs, which can differ from the submitted ones.
 """
 Base.@kwdef mutable struct CachedBOPTestPlant{EP <: AbstractBOPTestEndpoint} <: AbstractBOPTestPlant
     meta::BOPTestPlant{EP}
@@ -338,6 +332,57 @@ end
 
 ## Public API
 @deprecate initboptestservice!(boptest_url, testcase, dt; kwargs...) BOPTestPlant(boptest_url, testcase; dt, kwargs...)
+
+
+## Accessor methods
+"""
+    forecast_points(p::AbstractBOPTestPlant)
+
+Return forecast points as `DataFrame`.
+"""
+forecast_points(p::AbstractBOPTestPlant) = p.forecast_points
+
+"""
+    input_points(p::AbstractBOPTestPlant)
+
+Return forecast points as `DataFrame`.
+"""
+input_points(p::AbstractBOPTestPlant) = p.input_points
+
+"""
+    measurement_points(p::AbstractBOPTestPlant)
+
+Return measurement points as `DataFrame`.
+"""
+measurement_points(p::AbstractBOPTestPlant) = p.measurement_points
+
+
+"""
+    forecasts(p::CachedBOPTestPlant)
+
+Return forecasts from current time step as `DataFrame`.
+"""
+forecasts(p::CachedBOPTestPlant) = p.forecasts
+
+"""
+    past_inputs(p::CachedBOPTestPlant)
+
+Return past inputs to plant as `DataFrame`.
+
+In case the default was used for a signal, the entry will be `missing`.
+"""
+past_inputs(p::CachedBOPTestPlant) = p.inputs
+
+"""
+    measurements(p::CachedBOPTestPlant)
+
+Return measurements as `DataFrame`.
+
+Unlike `getmeasurements(p, ...)`, this method uses the local cache. This means
+that (1) the time step corresponds to the controller time step, and (2) also actually
+realized control inputs are available.
+"""
+measurements(p::CachedBOPTestPlant) = p.measurements
 
 
 """

--- a/src/BOPTestAPI.jl
+++ b/src/BOPTestAPI.jl
@@ -2,7 +2,7 @@ module BOPTestAPI
 
 export BOPTestPlant, CachedBOPTestPlant
 export forecast_points, input_points, measurement_points
-export forecasts, past_inputs, measurements
+export forecasts, inputs_sent, measurements
 export controlinputs
 export initboptest!, initialize!, advance!, setscenario!, stop!
 export getforecasts, getmeasurements, getkpi, getstep
@@ -205,7 +205,7 @@ function _create_input_df(plant::AbstractBOPTestPlant)
         "Number of '_activate' and '_u' inputs does not match"
     )
     
-    inputs = DataFrame()
+    inputs = DataFrame(:time => Float64[])
     for (act_col, val_col) in zip(int_input_cols, float_input_cols)
         insertcols!(inputs, act_col, val_col)
     end
@@ -340,21 +340,21 @@ end
 
 Return forecast points as `DataFrame`.
 """
-forecast_points(p::AbstractBOPTestPlant) = p.forecast_points
+forecast_points(p::AbstractBOPTestPlant) = copy(p.forecast_points)
 
 """
     input_points(p::AbstractBOPTestPlant)
 
 Return forecast points as `DataFrame`.
 """
-input_points(p::AbstractBOPTestPlant) = p.input_points
+input_points(p::AbstractBOPTestPlant) = copy(p.input_points)
 
 """
     measurement_points(p::AbstractBOPTestPlant)
 
 Return measurement points as `DataFrame`.
 """
-measurement_points(p::AbstractBOPTestPlant) = p.measurement_points
+measurement_points(p::AbstractBOPTestPlant) = copy(p.measurement_points)
 
 
 """
@@ -362,16 +362,19 @@ measurement_points(p::AbstractBOPTestPlant) = p.measurement_points
 
 Return forecasts from current time step as `DataFrame`.
 """
-forecasts(p::CachedBOPTestPlant) = p.forecasts
+forecasts(p::CachedBOPTestPlant) = copy(p.forecasts)
 
 """
-    past_inputs(p::CachedBOPTestPlant)
+    inputs_sent(p::CachedBOPTestPlant)
 
-Return past inputs to plant as `DataFrame`.
+Return past inputs sent to the plant as `DataFrame`.
 
-In case the default was used for a signal, the entry will be `missing`.
+Note that this contains values as sent; if out of bounds, the plant might use other values.
+Use `measurements` to get a `DataFrame` with the actually used inputs.
+
+In case the default was used for a signal, the entry here will be `missing`.
 """
-past_inputs(p::CachedBOPTestPlant) = p.inputs
+inputs_sent(p::CachedBOPTestPlant) = copy(p.inputs)
 
 """
     measurements(p::CachedBOPTestPlant)
@@ -382,7 +385,7 @@ Unlike `getmeasurements(p, ...)`, this method uses the local cache. This means
 that (1) the time step corresponds to the controller time step, and (2) also actually
 realized control inputs are available.
 """
-measurements(p::CachedBOPTestPlant) = p.measurements
+measurements(p::CachedBOPTestPlant) = copy(p.measurements)
 
 
 """
@@ -420,7 +423,7 @@ function initialize!(plant::CachedBOPTestPlant; kwargs...)
     res = initialize!(plant.meta)
 
     plant.forecasts = getforecasts(plant.meta, plant.N * plant.dt, plant.dt)
-    plant.measurements = _create_measurement_df(plant.meta)
+    plant.measurements = getmeasurements(plant.meta, 0, 0)
     plant.inputs = _create_input_df(plant.meta)
     return res
 end
@@ -532,14 +535,14 @@ Query measurements from BOPTEST server and return as `DataFrame`.
 - `convert_f64::Bool` : whether to convert column types to `Float64`, default `true`. \
 If set to `false`, the columns will have type `Any`.
 
-To obtain available measurement points, use `plant.measurement_points`, which is a 
-`DataFrame` with a column `:Name` that contains all available signals.
+To obtain available points, use `measurement_points(plant)` and `input_points(plant),
+which each return a `DataFrame` with a column `:Name` that contains all available signals.
 """
 function getmeasurements(
     plant::AbstractBOPTestPlant,
     starttime::Real,
     finaltime::Real,
-    points = plant.measurement_points.Name;
+    points = [plant.input_points.Name; plant.measurement_points.Name];
     convert_f64::Bool = true,
     kwargs...
 )
@@ -592,7 +595,7 @@ Query forecast from BOPTEST server and return as `DataFrame`.
 - `convert_f64::Bool` : whether to convert column types to `Float64`, default `true`. \
 If set to `false`, the columns will have type `Any`.
 
-Available forecast points are stored in `plant.forecast_points`. 
+Available forecast points are available using `forecast_points(plant)`. 
 """
 function getforecasts(
     plant::AbstractBOPTestPlant,
@@ -657,6 +660,7 @@ function advance!(
 
     push!(plant.measurements, payload)
     all_inputs = _complete_inputs(u, plant.input_points.Name)
+    all_inputs["time"] = fc[1, :time] - plant.dt
     push!(plant.inputs, all_inputs)
     
     return payload
@@ -715,7 +719,7 @@ end
 
 Return `Dict` with control signals for BOPTEST.
 
-This method calls `inputpoints(plant)` to gather available inputs,
+This method calls `input_points(plant)` to gather available inputs,
 and then creates a `Dict` with the available inputs as keys and
 default values defined by function `f`.
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -113,7 +113,7 @@ end
             advance!(plant, u)
         end
 
-        p_i = past_inputs(plant)
+        p_i = inputs_sent(plant)
         @test size(p_i, 1) == N_advance
         @test all(ismissing.(p_i[!, :oveTSet_u]))
         @test all(p_i[!, :oveHeaPumY_u] .== 0.3)
@@ -127,10 +127,13 @@ end
 
         initialize!(plant)
         m = measurements(plant)
-        i = past_inputs(plant)
-        fc = forecasts(plant)
-        @test size(m, 1) == 0
+        @test size(m, 1) == 1
+
+        i = inputs_sent(plant)
         @test size(i, 1) == 0
+        @test "time" in names(i)
+        
+        fc = forecasts(plant)       
         @test minimum(fc.time) == 0.0
         
     catch e

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,11 +24,11 @@ using Test
     try
         @test plant isa AbstractBOPTestPlant
         
-        fcpts = plant.forecast_points
+        fcpts = forecast_points(plant)
         @test "Name" in names(fcpts)
         @test size(fcpts, 1) > 0
 
-        @test size(plant.measurement_points, 1) > 0
+        @test size(measurement_points(plant), 1) > 0
 
         dfres = getmeasurements(plant, 0.0, 0.0) # DataFrame
         @test "time" in names(dfres)
@@ -103,9 +103,9 @@ end
         @test plant.N == N
 
         # To check Base.getproperty accessor
-        @test plant.input_points isa AbstractDataFrame
+        @test input_points(plant) isa AbstractDataFrame
 
-        @test size(plant.forecasts, 1) == N + 1
+        @test size(forecasts(plant), 1) == N + 1
         
         u = Dict("oveHeaPumY_activate" => 1, "oveHeaPumY_u" => 0.3)
         N_advance = 10
@@ -113,19 +113,25 @@ end
             advance!(plant, u)
         end
 
-        @test size(plant.inputs, 1) == N_advance
-        @test all(ismissing.(plant.inputs[!, :oveTSet_u]))
-        @test all(plant.inputs[!, :oveHeaPumY_u] .== 0.3)
+        p_i = past_inputs(plant)
+        @test size(p_i, 1) == N_advance
+        @test all(ismissing.(p_i[!, :oveTSet_u]))
+        @test all(p_i[!, :oveHeaPumY_u] .== 0.3)
 
-        @test size(plant.measurements, 1) == N_advance
-        @test all(diff(plant.measurements.time) .== dt)
+        m = measurements(plant)
+        @test size(m, 1) == N_advance
+        @test all(diff(m.time) .== dt)
 
-        @test minimum(plant.forecasts.time) == N_advance * dt
+        fc = forecasts(plant)
+        @test minimum(fc.time) == N_advance * dt
 
         initialize!(plant)
-        @test size(plant.measurements, 1) == 0
-        @test size(plant.inputs, 1) == 0
-        @test minimum(plant.forecasts.time) == 0.0
+        m = measurements(plant)
+        i = past_inputs(plant)
+        fc = forecasts(plant)
+        @test size(m, 1) == 0
+        @test size(i, 1) == 0
+        @test minimum(fc.time) == 0.0
         
     catch e
         rethrow(e)


### PR DESCRIPTION
Hide the field names from public API, and define methods instead