### PR TITLE
35 allow cachedboptestplant to have varying forecast length

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BOPTestAPI"
 uuid = "4c862b9d-90c3-47b4-a9d1-cc1c4398311d"
 authors = ["Bertrand Kerres"]
-version = "0.5.3"
+version = "0.6.0-DEV"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/src/BOPTestAPI.jl
+++ b/src/BOPTestAPI.jl
@@ -19,7 +19,7 @@ abstract type AbstractBOPTestEndpoint end
 # BOPTEST-Service (https://github.com/NREL/boptest-service)
 # runs several test cases in parallel
 struct BOPTestEndpoint <: AbstractBOPTestEndpoint
-    base_url::AbstractString
+    base_url::String
 end
 
 function (base::BOPTestEndpoint)(service::AbstractString)
@@ -29,8 +29,8 @@ end
 # BOPTEST (https://github.com/ibpsa/project1-boptest/) 
 # runs a single test case and thus doesn't have a testid
 struct BOPTestServiceEndpoint <: AbstractBOPTestEndpoint
-    base_url::AbstractString
-    testid::AbstractString
+    base_url::String
+    testid::String
 end
 
 function (base::BOPTestServiceEndpoint)(service::AbstractString)
@@ -54,10 +54,10 @@ Initialize a testcase in BOPTEST service.
 - `scenario::AbstractDict` : Parameters for scenario selection.
 
 """
-Base.@kwdef struct BOPTestPlant{EP <: AbstractBOPTestEndpoint} <: AbstractBOPTestPlant
+Base.@kwdef struct BOPTestPlant{EP <: AbstractBOPTestEndpoint, D <: AbstractDict} <: AbstractBOPTestPlant
     api_endpoint::EP
-    testcase::AbstractString
-    scenario::AbstractDict
+    testcase::String
+    scenario::D
 
     forecast_points::DataFrame
     input_points::DataFrame

--- a/src/BOPTestAPI.jl
+++ b/src/BOPTestAPI.jl
@@ -383,6 +383,11 @@ Return past inputs sent to the plant as `DataFrame`.
 Note that this contains values as sent; if out of bounds, the plant might use other values.
 Use `measurements` to get a `DataFrame` with the actually used inputs. In case the default
 was used for a signal, the entry here will be `missing`.
+
+The values in the `time` column give the plant time *after* the time step is completed, \
+not when it was sent. This matches the `time` column in `DataFrame` returned by \
+`measurement(plant)`.
+
 Use valid row and column selectors from `DataFrames.jl` for the keyword arguments.
 """
 inputs_sent(

--- a/src/BOPTestAPI.jl
+++ b/src/BOPTestAPI.jl
@@ -569,7 +569,7 @@ function getmeasurements(
     end
     
     # Type needed for dispatching on correct reduce(vcat, dfs) later
-    dfs::Vector{DataFrame} = []
+    dfs = DataFrame[]
     for (ts, te) in zip(query_timesteps[1:end-1], query_timesteps[2:end])
         body = Dict(
             "point_names" => points,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -105,7 +105,8 @@ end
         # To check Base.getproperty accessor
         @test input_points(plant) isa AbstractDataFrame
 
-        @test size(forecasts(plant), 1) >= N + 1
+        # Default forecasts(plant) returns N+1 rows, even if underlying cache is larger
+        @test size(forecasts(plant), 1) == N + 1
         @test size(measurements(plant), 1) == 1
         
         u = Dict("oveHeaPumY_activate" => 1, "oveHeaPumY_u" => 0.3)
@@ -123,12 +124,15 @@ end
         @test size(p_i, 1) == 3
         @test size(p_i, 2) == 2
 
+        ip2 = inputs_sent(plant)
         m = measurements(plant)
         @test size(m, 1) == N_advance + 1
         @test all(diff(m.time) .== dt)
+        @test m.time[2:end] == ip2.time
 
         fc = forecasts(plant)
         @test minimum(fc.time) == N_advance * dt
+        @test all(diff(fc.time) .== dt)
 
         initialize!(plant)
         m = measurements(plant)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -105,11 +105,11 @@ end
         # To check Base.getproperty accessor
         @test input_points(plant) isa AbstractDataFrame
 
-        @test size(forecasts(plant), 1) == N + 1
+        @test size(forecasts(plant), 1) >= N + 1
         @test size(measurements(plant), 1) == 1
         
         u = Dict("oveHeaPumY_activate" => 1, "oveHeaPumY_u" => 0.3)
-        N_advance = 10
+        N_advance = 48
         for t = 1:N_advance
             advance!(plant, u)
         end


### PR DESCRIPTION
`CachedBOPTestPlant` has a cache size varying between `plant.N` and `plant.Nmax`, to reduce the number of REST API calls.